### PR TITLE
Add perf test to compare smart vs dumb search implementations

### DIFF
--- a/word_core/examples/test_perf.rs
+++ b/word_core/examples/test_perf.rs
@@ -1,0 +1,106 @@
+use std::{cmp::min, env::args, fs, time::Instant};
+
+use word_core::{
+    dumb_word_search::dumb_search_words, hint::guess_to_hints, query_generation::clue_to_query,
+    word::Word, word_search::SearchableWords,
+};
+
+fn load_words() -> Vec<Word<5>> {
+    let file_path = args()
+        .nth(1)
+        .expect("Must supply word list file as first arg");
+    let file = fs::read_to_string(file_path).unwrap();
+    file.split("\n")
+        .map(|row| row.trim())
+        .filter(|row| row.len() > 0)
+        .map(|word| Word::from_str(word))
+        .collect()
+}
+
+fn main() {
+    let words = load_words();
+
+    let limit_trials: Option<usize> = args().nth(2).map(|limit| limit.parse().ok()).flatten();
+
+    let num_trials = match limit_trials {
+        Some(limit) => min(limit, words.len() * words.len()),
+        None => words.len() * words.len(),
+    };
+
+    println!("loaded {} words, {} test cases", words.len(), num_trials);
+
+    let smart_search: SearchableWords<5, 26> = SearchableWords::build(words.clone());
+
+    println!("<- testing dumb search ->");
+    let start = Instant::now();
+    let mut i = 0;
+    for answer in &words {
+        for guess in &words {
+            if i >= num_trials {
+                break;
+            }
+            if i % 10000 == 0 {
+                let elapsed_s = start.elapsed().as_secs_f64();
+                let total_est = (elapsed_s * num_trials as f64) / i as f64;
+                println!(
+                    "finished {} in {:.3}s - {:.2} iter/s - {:.3}s remaining - {:.3}s total",
+                    i,
+                    elapsed_s,
+                    i as f64 / elapsed_s,
+                    total_est - elapsed_s,
+                    total_est,
+                );
+            }
+
+            let hints = guess_to_hints(*answer, *guess);
+
+            // Get possible answers via dumb search
+            dumb_search_words(&words, *guess, hints);
+            i += 1;
+        }
+    }
+    let total_elapsed = start.elapsed().as_secs_f64();
+    println!(
+        "finished {} in {:.3}s - {:.2} iter/s",
+        num_trials,
+        total_elapsed,
+        num_trials as f64 / total_elapsed
+    );
+
+    println!("<- testing smart search ->");
+    let start = Instant::now();
+    let mut i = 0;
+    for answer in &words {
+        for guess in &words {
+            if i >= num_trials {
+                break;
+            }
+            if i % 10000 == 0 {
+                let elapsed_s = start.elapsed().as_secs_f64();
+                let total_est = (elapsed_s * num_trials as f64) / i as f64;
+                println!(
+                    "finished {} in {:.3}s - {:.2} iter/s - {:.3}s remaining - {:.3}s total",
+                    i,
+                    elapsed_s,
+                    i as f64 / elapsed_s,
+                    total_est - elapsed_s,
+                    total_est,
+                );
+            }
+
+            let hints = guess_to_hints(*answer, *guess);
+
+            // Get possible answers via smart search
+            let query = clue_to_query(*guess, hints);
+            smart_search.filter_words(&smart_search.eval_query(query.clone()));
+            i += 1;
+        }
+    }
+    let total_elapsed = start.elapsed().as_secs_f64();
+    println!(
+        "finished {} in {:.3}s - {:.2} iter/s",
+        num_trials,
+        total_elapsed,
+        num_trials as f64 / total_elapsed
+    );
+}


### PR DESCRIPTION
### Results (single-threaded on M2 Max)

| Word List | Word List Size | Dumb iter/s | Smart iter/s | Smart multiple |
| - | - | - | - | - |
| very-common | 483 | 5065.50 | 481978.58 | 95.14x |
| possible-answers | 2315 | 1068.69 | 243003.58 | 227.38x |
| common | 3103 | 801.14 | 221623.80 | 276.63x |
| allowed-guesses | 14855 | 169.71 | 71849.30 | 423.36x | 

Note that this includes time to compute hints via `guess_to_hints`, which is fast but adds a fixed cost per iter.

These results reflect that dumb search takes `408*n` nanoseconds per search, while smart search takes `1677 + 0.8240*n` ns per search (`n` = word list size). So as word list size increases, smart search performance asymptotically approaches ~500x times faster.

So both search systems are linear wrt the word list size, but smart search has a far better coefficient.