### PR TITLE
Compute hints from answers instead of answers from hints

### DIFF
--- a/word_core/src/decision_tree.rs
+++ b/word_core/src/decision_tree.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, f64::INFINITY};
+use std::{
+    collections::{HashMap, HashSet},
+    f64::INFINITY,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -117,7 +120,13 @@ pub fn compute_node_aggressive<const WORD_SIZE: usize>(
         let mut guess_decision_tree: HashMap<WordHint<WORD_SIZE>, TreeNode<WORD_SIZE>> =
             HashMap::new();
         let mut guess_est_cost = 1.0;
-        let possible_hints = WordHint::all_possible();
+        let possible_hints: Vec<WordHint<WORD_SIZE>> = possible_answers
+            .words()
+            .iter()
+            .map(|answer| WordHint::from_guess_and_answer(guess, answer))
+            .collect::<HashSet<WordHint<WORD_SIZE>>>()
+            .into_iter()
+            .collect();
         let num_possible_hints = possible_hints.len();
         let mut answers_accounted_for = 0;
         for (word_hint_ind, word_hint) in possible_hints.into_iter().enumerate() {


### PR DESCRIPTION
An understanding that `SearchableWords` is faster than a simple scan (see #1) originally drove an implementation choice to fan-out to all possible hints, on the assumption that `SearchableWords` would be fast enough to make the useless hints ineffectual on runtime.

However, analyzing the runtime performance found that the vast majority of hints being checked led to no possible answers, costing significant useless computation.

An alternate approach was considered - instead of evaluating every possible hint and filtering based on which are applicable to this combination of a guess and possible answer list - just move through the answer list and directly compute which hints are possible.

On the hypothesis that this approach would be faster when the number of possible answers is small, performance was evaluated across several datasets and cutoffs[^1][^2]:
| Cutoff | time (test)[^3] | time (very-common)[^4] | time (allowed-guesses)[^5] |
| - | ----------- | ------------------ | ---------------------- |
| 0     | 10.148 | 7.966 | 29.804 |
| 5     | 5.971  | 1.013 | 4.091 |
| 10    | 4.713  | 1.010 | 4.101 |
| 50    | 4.212  | 1.013 | 4.122 |
| 100   |        | 1.008 | 4.115 |
| 500   |        | 1.012 | 4.116 |
| 1000  |        |       | 4.111 |
| 15000 |        |       | 4.131 |

These results surprisingly show that the new hint generation is practically never slower than the original version, even for very high cutoff values. As such, we can update to only ever use this new version.

[^1]: Cutoff: if num possible answers <= Cutoff, use new hint generation
[^2]: execution times averaged over 3 runs, using max search depth of 4
[^3]: for test dataset, using first 10 level-0 guesses
[^4]: for very-common dataset, using first 400 level-1 guesses, always using old-version hints at level 0 for consistency
[^5]: for allowed-guesses dataset, using first 100 level-2 guesses, always using old-version hints at level 0 for consistency