### PR TITLE
Precompute possible hints per guess

### DIFF
--- a/word_core/examples/test_compute_possible_hints_perf.rs
+++ b/word_core/examples/test_compute_possible_hints_perf.rs
@@ -74,19 +74,6 @@ fn main() {
             if answers_giving_this_hint_mask.count_true() > 0 {
                 possible_hints.insert(hint);
             }
-            for answer_giving_this_hint in
-                searchable_answers.filter_words(&answers_giving_this_hint_mask)
-            {
-                let actual_hint = WordHint::from_guess_and_answer(guess, &answer_giving_this_hint);
-                if actual_hint != hint {
-                    println!(
-                        "ERROR: Query engine came up with wrong hint for {} | {}",
-                        guess, answer_giving_this_hint
-                    );
-                    println!("calc'd: {}", hint.color_guess(guess));
-                    println!("actual: {}", actual_hint.color_guess(guess));
-                }
-            }
         }
         possible_hints_per_guess_query_engine.insert(*guess, possible_hints);
     }

--- a/word_core/examples/test_compute_possible_hints_perf.rs
+++ b/word_core/examples/test_compute_possible_hints_perf.rs
@@ -74,19 +74,19 @@ fn main() {
             if answers_giving_this_hint_mask.count_true() > 0 {
                 possible_hints.insert(hint);
             }
-            // for answer_giving_this_hint in
-            //     searchable_answers.filter_words(&answers_giving_this_hint_mask)
-            // {
-            //     let actual_hint = WordHint::from_guess_and_answer(guess, &answer_giving_this_hint);
-            //     if actual_hint != hint {
-            //         println!(
-            //             "ERROR: Query engine came up with wrong hint for {} | {}",
-            //             guess, answer_giving_this_hint
-            //         );
-            //         println!("calc'd: {}", hint.color_guess(guess));
-            //         println!("actual: {}", actual_hint.color_guess(guess));
-            //     }
-            // }
+            for answer_giving_this_hint in
+                searchable_answers.filter_words(&answers_giving_this_hint_mask)
+            {
+                let actual_hint = WordHint::from_guess_and_answer(guess, &answer_giving_this_hint);
+                if actual_hint != hint {
+                    println!(
+                        "ERROR: Query engine came up with wrong hint for {} | {}",
+                        guess, answer_giving_this_hint
+                    );
+                    println!("calc'd: {}", hint.color_guess(guess));
+                    println!("actual: {}", actual_hint.color_guess(guess));
+                }
+            }
         }
         possible_hints_per_guess_query_engine.insert(*guess, possible_hints);
     }

--- a/word_core/examples/test_compute_possible_hints_perf.rs
+++ b/word_core/examples/test_compute_possible_hints_perf.rs
@@ -1,0 +1,143 @@
+use std::{
+    collections::{HashMap, HashSet},
+    env::args,
+    fs,
+    time::Instant,
+};
+
+use word_core::{
+    hint::WordHint,
+    query_generation::{clue_possible, clue_to_query},
+    word::Word,
+    word_search::SearchableWords,
+};
+
+const WORD_SIZE: usize = 5;
+const ALPHABET_SIZE: u8 = 26;
+
+fn load_words(file_path: String) -> Vec<Word<WORD_SIZE, ALPHABET_SIZE>> {
+    let file = fs::read_to_string(file_path).unwrap();
+    file.split("\n")
+        .map(|row| row.trim())
+        .filter(|row| row.len() > 0)
+        .map(|word| Word::from_str(word))
+        .collect()
+}
+
+fn main() {
+    let allowed_guesses = load_words(
+        args()
+            .nth(1)
+            .expect("Must supply allowed guesses word list file as first arg"),
+    );
+    println!("loaded {} allowed guesses", allowed_guesses.len());
+
+    let possible_answers = load_words(
+        args()
+            .nth(2)
+            .expect("Must supply possible answers word list file as second arg"),
+    );
+    println!("loaded {} possible answers", possible_answers.len());
+
+    println!("<- testing simple scan ->");
+    let start = Instant::now();
+    let mut possible_hints_per_guess_simple: HashMap<
+        Word<WORD_SIZE, ALPHABET_SIZE>,
+        HashSet<WordHint<WORD_SIZE>>,
+    > = HashMap::new();
+    for guess in &allowed_guesses {
+        let mut possible_hints: HashSet<WordHint<WORD_SIZE>> = HashSet::new();
+        for answer in &possible_answers {
+            let hint = WordHint::from_guess_and_answer(&guess, answer);
+            possible_hints.insert(hint);
+        }
+        possible_hints_per_guess_simple.insert(*guess, possible_hints);
+    }
+    let total_elapsed = start.elapsed().as_secs_f64();
+    println!("finished in {:.3}s", total_elapsed);
+
+    println!("<- testing query engine scan ->");
+    let start = Instant::now();
+    let mut possible_hints_per_guess_query_engine: HashMap<
+        Word<WORD_SIZE, ALPHABET_SIZE>,
+        HashSet<WordHint<WORD_SIZE>>,
+    > = HashMap::new();
+    let searchable_answers = SearchableWords::build(possible_answers);
+    for guess in &allowed_guesses {
+        let mut possible_hints: HashSet<WordHint<WORD_SIZE>> = HashSet::new();
+        for hint in WordHint::all_possible() {
+            if !clue_possible(*guess, hint) {
+                continue;
+            }
+            let answers_giving_this_hint_mask =
+                searchable_answers.eval_query(clue_to_query(*guess, hint));
+            if answers_giving_this_hint_mask.count_true() > 0 {
+                possible_hints.insert(hint);
+            }
+            // for answer_giving_this_hint in
+            //     searchable_answers.filter_words(&answers_giving_this_hint_mask)
+            // {
+            //     let actual_hint = WordHint::from_guess_and_answer(guess, &answer_giving_this_hint);
+            //     if actual_hint != hint {
+            //         println!(
+            //             "ERROR: Query engine came up with wrong hint for {} | {}",
+            //             guess, answer_giving_this_hint
+            //         );
+            //         println!("calc'd: {}", hint.color_guess(guess));
+            //         println!("actual: {}", actual_hint.color_guess(guess));
+            //     }
+            // }
+        }
+        possible_hints_per_guess_query_engine.insert(*guess, possible_hints);
+    }
+    let total_elapsed = start.elapsed().as_secs_f64();
+    println!("finished in {:.3}s", total_elapsed);
+
+    assert_eq!(
+        possible_hints_per_guess_simple
+            .keys()
+            .into_iter()
+            .cloned()
+            .collect::<HashSet<Word<WORD_SIZE, ALPHABET_SIZE>>>(),
+        allowed_guesses
+            .iter()
+            .cloned()
+            .collect::<HashSet<Word<WORD_SIZE, ALPHABET_SIZE>>>()
+    );
+    assert_eq!(
+        possible_hints_per_guess_query_engine
+            .keys()
+            .into_iter()
+            .cloned()
+            .collect::<HashSet<Word<WORD_SIZE, ALPHABET_SIZE>>>(),
+        allowed_guesses
+            .iter()
+            .cloned()
+            .collect::<HashSet<Word<WORD_SIZE, ALPHABET_SIZE>>>()
+    );
+    for guess in &allowed_guesses {
+        let possible_hints_simple = possible_hints_per_guess_simple.get(guess).unwrap();
+        let possible_hints_query_engine = possible_hints_per_guess_query_engine.get(guess).unwrap();
+
+        let a_not_b: HashSet<&WordHint<WORD_SIZE>> = possible_hints_simple
+            .difference(possible_hints_query_engine)
+            .collect();
+        let b_not_a: HashSet<&WordHint<WORD_SIZE>> = possible_hints_query_engine
+            .difference(possible_hints_simple)
+            .collect();
+
+        if a_not_b.len() > 0 || b_not_a.len() > 0 {
+            println!("Two scans got different results for {}", guess);
+            println!("Hints discovered by simple scan but not query engine:");
+            for hint in a_not_b {
+                println!("{}", hint);
+            }
+            println!("Hints discovered by query engine but not simple scan:");
+            for hint in b_not_a {
+                println!("{}", hint);
+            }
+            println!("");
+        }
+    }
+    println!("both scans gave equivalent results")
+}

--- a/word_core/src/query_generation.rs
+++ b/word_core/src/query_generation.rs
@@ -6,6 +6,35 @@ use crate::{
     word_search::Query,
 };
 
+/// Check whether a clue is possible for a given word.
+///
+/// The case this looks for is Elsewhere hints after Nowhere hints for a given char.
+/// The default wordle hint generation will always fill the first characters possible
+/// with Elsewhere hints.
+pub fn clue_possible<const WORD_SIZE: usize, const ALPHABET_SIZE: u8>(
+    guess: Word<WORD_SIZE, ALPHABET_SIZE>,
+    word_hint: WordHint<WORD_SIZE>,
+) -> bool {
+    let mut nowhere_chars: HashSet<u8> = HashSet::new();
+    for ind in 0..WORD_SIZE {
+        let guess_char = guess.0[ind];
+        let char_hint = word_hint.0[ind];
+
+        match char_hint {
+            CharHint::Nowhere => {
+                nowhere_chars.insert(guess_char);
+            }
+            CharHint::Elsewhere => {
+                if nowhere_chars.contains(&guess_char) {
+                    return false;
+                }
+            }
+            CharHint::Correct => {}
+        }
+    }
+    true
+}
+
 pub fn clue_to_query<const WORD_SIZE: usize, const ALPHABET_SIZE: u8>(
     guess: Word<WORD_SIZE, ALPHABET_SIZE>,
     word_hint: WordHint<WORD_SIZE>,


### PR DESCRIPTION
Context: currently evaluating whether it's worthwhile to pre-compute all the possible hints for a given guess before beginning search, to reduce expensive exploration of possible hints while traversing.

This PR is comparing the performance of two possible approaches to achieve this pre-computation, with the new `test_compute_possible_hints` example script. The two considered approaches:
1. "simple scan" - checking every guess/answer combination and de-duping hints
2. "query engine" - using the `SearchableWords` structure and checking every possible hint to determine which lead to >1 possible answer

The results of the performance test are:
| "allowed guesses" word list (size) | "possible answers" word list (size) | simple scan time | query engine time |
| - | - | - | - |
| test (50) | test (50) | 0.001s | 0.001s |
| very-common (483) | very-common (483) | 0.168s | 0.151s |
| common (3103) | common (3103) | 6.169s | 1.149s |
| competition-allowed-guesses (10657) | possible-answers (2315) | 15.725s | 3.705s |
| allowed-guesses (14855) | allowed-guesses (14855) | 141.587s | 6.150s |

These results clearly show that the query engine is significantly more performant for pre-computing all possible hints per guess, especially as input sizes grow.

---

Note that an fix was also included in this PR under 74d24140ac1a4cdbb4c526799c665efce4bd3524 - the clue-to-query generation can happily spit out queries for clues that are not realistically possible. Thus, it was incorrect to assume that answers output from search would be unique to a given hint input. This is mitigated by a new `clue_possible` helper that filters out word / hint combinations are are never possible, such as:
```
FOO
√X~
```
since default hint generation will always hint `~` eagerly, consistently giving an actual hint of `√~X` in any scenario,